### PR TITLE
Added Lock Door Status (August DoorSense)

### DIFF
--- a/august/lock.py
+++ b/august/lock.py
@@ -44,3 +44,8 @@ class LockStatus(Enum):
     LOCKED = "locked"
     UNLOCKED = "unlocked"
     UNKNOWN = "unknown"
+
+class LockDoorStatus(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    UNKNOWN = "unknown"

--- a/tests/fixtures/get_lock.json
+++ b/tests/fixtures/get_lock.json
@@ -13,6 +13,7 @@
   "SerialNumber": "X2FSW05DGA",
   "LockStatus": {
     "status": "locked",
+    "doorState": "closed",
     "dateTime": "2017-12-10T04:48:30.272Z",
     "isLockStatusChanged": true,
     "valid": true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -172,6 +172,45 @@ class TestApi(unittest.TestCase):
         self.assertEqual(LockStatus.UNKNOWN, status)
 
     @requests_mock.Mocker()
+    def test_get_lock_door_status_with_closed_response(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            text="{\"doorState\": \"kAugLockDoorState_Closed\"}")
+
+        api = Api()
+        doorStatus = api.get_lock_door_status(ACCESS_TOKEN, lock_id)
+
+        self.assertEqual(LockDoorStatus.CLOSED, doorStatus)
+
+    @requests_mock.Mocker()
+    def test_get_lock_door_status_with_open_response(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            text="{\"doorState\": \"kAugLockDoorState_Open\"}")
+
+        api = Api()
+        doorStatus = api.get_lock_door_status(ACCESS_TOKEN, lock_id)
+
+        self.assertEqual(LockDoorStatus.OPEN, doorStatus)
+
+    @requests_mock.Mocker()
+    def test_get_lock_door_status_with_unknown_response(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            text="{\"doorState\": \"not_advertising\"}")
+
+        api = Api()
+        doorStatus = api.get_lock_door_status(ACCESS_TOKEN, lock_id)
+
+        self.assertEqual(LockDoorStatus.UNKNOWN, doorStatus)
+        
+    @requests_mock.Mocker()
     def test_lock(self, mock):
         lock_id = 1234
         mock.register_uri(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ import requests_mock
 from august.api import API_GET_DOORBELLS_URL, Api, API_GET_LOCKS_URL, \
     API_GET_LOCK_STATUS_URL, API_LOCK_URL, API_UNLOCK_URL, API_GET_LOCK_URL, \
     API_GET_DOORBELL_URL
-from august.lock import LockStatus
+from august.lock import LockStatus, LockDoorStatus
 
 ACCESS_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
 


### PR DESCRIPTION
Added new method to get the "doorState" attribute which is reported by all new August Locks (not only the pro) when the included "DoorSense" sensor is installed on the door.
I plan to create a new sensor based on this on Home Assistant, so I do not have to install additional ZWave or Zigbee sensors for doors where I have August locks.