### PR TITLE
Use session and combine lock with door status

### DIFF
--- a/august/api.py
+++ b/august/api.py
@@ -100,7 +100,11 @@ class Api:
             pass
 
     def close(self):
-        """ Close the session """
+        """ Close the session
+
+        This method should be called before removing last reference to the
+        created Api instance to close the session.
+        """
         if self._http_session is not None:
             self._http_session.close()
 

--- a/august/api.py
+++ b/august/api.py
@@ -1,6 +1,6 @@
 import logging
 
-import requests
+from requests import request, Session
 
 from august.activity import DoorbellDingActivity, DoorbellMotionActivity, \
     DoorbellViewActivity, LockOperationActivity
@@ -82,31 +82,11 @@ def _determine_lock_door_status(status):
 
 
 class Api:
-    def __init__(self, timeout=10, command_timeout=60, use_http_session=False):
+    def __init__(self, timeout=10, command_timeout=60,
+                 http_session: Session = None):
         self._timeout = timeout
         self._command_timeout = command_timeout
-        self._http_session = requests.Session() if use_http_session else None
-
-    def __del__(self):
-        """ Close the session if exist when this instance is destroyed
-
-        Not liked by all or everyone, but implementing this as an "in-case"
-        When Api class is called with use_http_session=True then method close
-        should be called to close the session before removing last reference
-        """
-        try:
-            self.close()
-        except Exception:
-            pass
-
-    def close(self):
-        """ Close the session
-
-        This method should be called before removing last reference to the
-        created Api instance to close the session.
-        """
-        if self._http_session is not None:
-            self._http_session.close()
+        self._http_session = http_session
 
     def get_session(self, install_id, identifier, password):
         response = self._call_api(
@@ -285,7 +265,7 @@ class Api:
 
         response = self._http_session.request(method, url, **kwargs) if\
             self._http_session is not None else\
-            requests.request(method, url, **kwargs)
+            request(method, url, **kwargs)
 
         _LOGGER.debug("Received API response: %s, %s", response.status_code,
                       response.content)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -147,6 +147,22 @@ class TestApi(unittest.TestCase):
         self.assertEqual(LockStatus.LOCKED, status)
 
     @requests_mock.Mocker()
+    def test_get_lock_and_door_status_with_locked_response(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            text="{\"status\": \"kAugLockState_Locked\""
+                ",\"doorState\": \"kAugLockDoorState_Closed\"}")
+
+        api = Api()
+        status, door_status = api.get_lock_status(ACCESS_TOKEN, lock_id, True)
+
+        self.assertEqual(LockStatus.LOCKED, status)
+        self.assertEqual(LockDoorStatus.CLOSED, door_status)
+
+
+    @requests_mock.Mocker()
     def test_get_lock_status_with_unlocked_response(self, mock):
         lock_id = 1234
         mock.register_uri(
@@ -197,6 +213,22 @@ class TestApi(unittest.TestCase):
         door_status = api.get_lock_door_status(ACCESS_TOKEN, lock_id)
 
         self.assertEqual(LockDoorStatus.OPEN, door_status)
+
+    @requests_mock.Mocker()
+    def test_get_lock_and_door_status_with_open_response(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            text="{\"status\": \"kAugLockState_Unlocked\""
+                ",\"doorState\": \"kAugLockDoorState_Open\"}")
+
+        api = Api()
+        door_status, status = api.get_lock_door_status(ACCESS_TOKEN, lock_id,
+                                                       True)
+
+        self.assertEqual(LockDoorStatus.OPEN, door_status)
+        self.assertEqual(LockStatus.UNLOCKED, status)
 
     @requests_mock.Mocker()
     def test_get_lock_door_status_with_unknown_response(self, mock):


### PR DESCRIPTION
@snjoetw 

This change will use session from Requests to re-use the same connection when retrieving status (or sending commands). Also made a change to allow one to retrieve both lock and door state in 1 call (optional) as for both the information is retrieved from the same URL in August. 

Did testing to determine what the performance difference would be:

```
Test:
	100 iterations to retrieve door_status, lock_status, and detail_status.
	Use process_time from time to get CPU time; perf_counter from time to get execution time.
	Execution timers are within CPU timers.
	Times are retrieved:
		before import
		after import (= Import time)
		after August setup (= Import + Setup time)
		within loop before and then after executing api calls.
		after loop to retrieve lock information (= Import + Setup + Loop)
	CPU timers retrieved before execution timer and then after execution timer

Result:
	Using session and combining door_status with lock results in 71 seconds faster execution time with 7.4 seconds less CPU time
	Using session results in 63 seconds faster execution time with 6.8 seconds less CPU time.

	Using session results in each request being 213ms faster compared to not using session.

```
Here is the test program I used:
[August_Test.py.txt](https://github.com/snjoetw/py-august/files/2507707/August_Test.py.txt)

Here are the test results.
[August_Test_results.txt](https://github.com/snjoetw/py-august/files/2507702/August_Test_results.txt)

I think that these changes will be beneficial for HASS especially when there are people with doorbell and multiple locks (with these locks then also having door sensors).
Clearly to use session would then require code changing to HASS to enable it but that is something I will do if this PR is approved and merged.

@Jefronty, I understand by using Session it would then not be possible to implement your PR (although I did use your idea for combining door/lock status; thanks!!!). However I would think that this is not really to be called as a command line but rather to be called where the status is then retrieved on a regular basis. But will leave it up to owner on how he wants to proceed. :-)