### PR TITLE
Adding support for lock keypads and get pins

### DIFF
--- a/august/api.py
+++ b/august/api.py
@@ -2,10 +2,23 @@ import logging
 
 import requests
 
-from august.activity import DoorbellDingActivity, DoorbellMotionActivity, \
-    DoorbellViewActivity, LockOperationActivity
-from august.doorbell import Doorbell, DoorbellDetail
-from august.lock import Lock, LockStatus, LockDoorStatus, LockDetail
+from august.activity import (
+    DoorbellDingActivity,
+    DoorbellMotionActivity,
+    DoorbellViewActivity,
+    LockOperationActivity
+)
+from august.doorbell import (
+    Doorbell,
+    DoorbellDetail
+)
+from august.pin import Pin
+from august.lock import (
+    Lock,
+    LockDetail,
+    LockDoorStatus,
+    LockStatus,
+)
 
 HEADER_ACCEPT_VERSION = "Accept-Version"
 HEADER_AUGUST_ACCESS_TOKEN = "x-august-access-token"
@@ -38,8 +51,10 @@ API_GET_HOUSE_URL = API_BASE_URL + "/houses/{house_id}"
 API_GET_LOCKS_URL = API_BASE_URL + "/users/locks/mine"
 API_GET_LOCK_URL = API_BASE_URL + "/locks/{lock_id}"
 API_GET_LOCK_STATUS_URL = API_BASE_URL + "/locks/{lock_id}/status"
+API_GET_PINS_URL = API_BASE_URL + "/locks/{lock_id}/pins"
 API_LOCK_URL = API_BASE_URL + "/remoteoperate/{lock_id}/lock"
 API_UNLOCK_URL = API_BASE_URL + "/remoteoperate/{lock_id}/unlock"
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,6 +237,14 @@ class Api:
             access_token=access_token).json()
 
         return _determine_lock_door_status(json["doorState"])
+
+    def get_pins(self, access_token, lock_id):
+        json = self._call_api(
+            "get",
+            API_GET_PINS_URL.format(lock_id=lock_id),
+            access_token=access_token
+        ).json()
+        return [Pin(**pin) for pin in json.get('loaded', [])]
 
     def lock(self, access_token, lock_id):
         json = self._call_api(

--- a/august/keypad.py
+++ b/august/keypad.py
@@ -3,7 +3,6 @@ from august.device import DeviceDetail
 
 class KeypadDetail(DeviceDetail):
     def __init__(self, house_id, data):
-        print(data)
         super().__init__(
             data["_id"],
             None,

--- a/august/keypad.py
+++ b/august/keypad.py
@@ -1,0 +1,19 @@
+from august.device import DeviceDetail
+
+
+class KeypadDetail(DeviceDetail):
+    def __init__(self, house_id, data):
+        print(data)
+        super().__init__(
+            data["_id"],
+            None,
+            house_id,
+            data["serialNumber"],
+            data["currentFirmwareVersion"]
+        )
+
+        self._battery_level = data["batteryLevel"]
+
+    @property
+    def battery_level(self):
+        return self._battery_level

--- a/august/lock.py
+++ b/august/lock.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from august.device import Device, DeviceDetail
+from august.keypad import KeypadDetail
 
 
 class Lock(Device):
@@ -10,7 +11,6 @@ class Lock(Device):
             data["LockName"],
             data["HouseID"],
         )
-
         self._user_type = data["UserType"]
 
     @property
@@ -33,11 +33,21 @@ class LockDetail(DeviceDetail):
             data["SerialNumber"],
             data["currentFirmwareVersion"])
 
+        if 'keypad' in data:
+            self._keypad_detail = KeypadDetail(self.house_id, data['keypad'])
+        else:
+            self._keypad_detail = None
+
         self._battery_level = int(100 * data["battery"])
 
     @property
     def battery_level(self):
         return self._battery_level
+
+    @property
+    def keypad(self):
+        return self._keypad_detail
+
 
 
 class LockStatus(Enum):

--- a/august/pin.py
+++ b/august/pin.py
@@ -1,0 +1,61 @@
+import dateutil.parser
+
+class Pin(object):
+    def __init__(self, _id, lockID, userID, state, pin, slot,
+                 accessType, createdAt, updatedAt, loadedDate,
+                 firstName, lastName, unverified, accessStartTime=None,
+                 accessEndTime=None, accessTimes=None):
+        self.id = _id
+        self.lockID = lockID
+        self.userID = userID
+        self.state = state
+        self.pin = pin
+        self.slot = slot
+        self.accessType = accessType
+        self.firstName = firstName
+        self.lastName = lastName
+        self.unverified = unverified
+
+        self._createdAt = createdAt
+        self._updatedAt = updatedAt
+        self._loadedDate = loadedDate
+        self._accessStartTime = accessStartTime
+        self._accessEndTime = accessEndTime
+        self._accessTimes = accessTimes
+
+    @property
+    def createdAt(self):
+        return dateutil.parser.parse(self._createdAt)
+
+    @property
+    def updatedAt(self):
+        return dateutil.parser.parse(self._updatedAt)
+
+    @property
+    def loadedDate(self):
+        return dateutil.parser.parse(self._loadedDate)
+
+    @property
+    def accessStartTime(self):
+        if not self._accessStartTime:
+            return None
+        return dateutil.parser.parse(self._accessStartTime)
+
+    @property
+    def accessEndTime(self):
+        if not self._accessEndTime:
+            return None
+        return dateutil.parser.parse(self._accessEndTime)
+
+    @property
+    def accessTimes(self):
+        if not self._accessTimes:
+            return None
+        return dateutil.parser.parse(self._accessTimes)
+
+    def __repr__(self):
+        return "Pin(id={} firstName={}, lastName={})".format(
+            self.id,
+            self.firstName,
+            self.lastName
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 vol
+python-dateutil

--- a/tests/fixtures/get_lock.json
+++ b/tests/fixtures/get_lock.json
@@ -29,6 +29,15 @@
     "firmwareVersion": "2.3.0-RC153+201711151527",
     "operative": true
   },
+  "keypad": {
+    "_id": "5bc65c24e6ef2a263e1450a8",
+    "serialNumber": "K1GXB0054Z",
+    "lockID": "92412D1B44004595B5DEB134E151A8D3",
+    "currentFirmwareVersion": "2.27.0",
+    "battery": {},
+    "batteryLevel": "Medium",
+    "batteryRaw": 170
+  },
   "OfflineKeys": {
     "created": [],
     "loaded": [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -132,6 +132,8 @@ class TestApi(unittest.TestCase):
         self.assertEqual("X2FSW05DGA", lock.serial_number)
         self.assertEqual("109717e9-3.0.44-3.0.30", lock.firmware_version)
         self.assertEqual(88, lock.battery_level)
+        self.assertEqual("Medium", lock.keypad.battery_level)
+        self.assertEqual("5bc65c24e6ef2a263e1450a8", lock.keypad.device_id)
 
     @requests_mock.Mocker()
     def test_get_lock_status_with_locked_response(self, mock):


### PR DESCRIPTION
The `get_lock_detail` already returns information about the keypad if one is installed. Adding support for keypad information on `LockDetail` when it's available.

Also adding a new endpoint to get information about keypad pins.