### PR TITLE
Set install_requires for pip deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     author='snjoetw',
     author_email='snjoetw@gmail.com',
     description='Python API for August Smart Lock and Doorbell',
-    requires=['requests', 'vol']
+    install_requires=['requests', 'vol']
 )


### PR DESCRIPTION
This change fixes the pip install dependencies per https://packaging.python.org/discussions/install-requires-vs-requirements/

Current State:
```
aijay-mbp:venvs aijay$ python3 -m venv pyaug
aijay-mbp:venvs aijay$ source pyaug/bin/activate
(pyaug) aijay-mbp:venvs aijay$ pip install py-august
Collecting py-august
  Downloading https://files.pythonhosted.org/packages/47/0a/4dc955657d407455d7fc844693122eaaae5127122f2f87680d505cf2180f/py-august-0.9.0.tar.gz
Installing collected packages: py-august
  Running setup.py install for py-august ... done
Successfully installed py-august-0.9.0
(pyaug) aijay-mbp:venvs aijay$ pip freeze
py-august==0.9.0
```

With change:

```
(pyaug) aijay-mbp:py-august aijay$ pipdeptree
pipdeptree==0.13.2
  - pip [required: >=6.0.0, installed: 9.0.1]
py-august==0.8.0
  - requests [required: Any, installed: 2.22.0]
    - certifi [required: >=2017.4.17, installed: 2019.6.16]
    - chardet [required: >=3.0.2,<3.1.0, installed: 3.0.4]
    - idna [required: >=2.5,<2.9, installed: 2.8]
    - urllib3 [required: >=1.21.1,<1.26,!=1.25.1,!=1.25.0, installed: 1.25.3]
  - vol [required: Any, installed: 0.1.1]
    - docopt [required: Any, installed: 0.6.2]
setuptools==28.8.0
```