### PR TITLE
Add support for refreshing access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ ENV/
 # mypy
 .mypy_cache/
 .idea
+
+# IDEs
+.vscode/

--- a/august/api.py
+++ b/august/api.py
@@ -275,6 +275,14 @@ class Api:
 
         return _determine_lock_status(json.get("status"))
 
+    def refresh_access_token(self, access_token):
+        response = self._call_api(
+            "get",
+            API_GET_HOUSES_URL,
+            access_token=access_token)
+
+        return response.headers[HEADER_AUGUST_ACCESS_TOKEN]
+
     def _call_api(self, method, url, access_token=None, **kwargs):
         payload = kwargs.get("params") or kwargs.get("json")
 


### PR DESCRIPTION
Firstly -- thanks for putting together this library.  I use the HASS August integration heavily, and am very grateful for your work.

## Motivation

Access tokens expire after three months.  The last time I had to delete the cache and reboot HomeAssistant, I decided I'd dig into whether this was necessary (after all, the August app doesn't require you to re-login).

Looks like this can be avoided.  

## Background

I dug around in mitmproxy and noticed that API responses always include a `x-august-access-token` header with a fresh access token.  Observations:

* By decoding the token (it's a JWT), you can see that the expiration of this token will be three months from the time the request is made, regardless of when the the token was originally issued.
* The next request coming from the August app will use the token contained in the response of the previous one.

Looks like this is how the August app is keeping tokens fresh.

## Summary of Changes

I added two methods:

* `Api.refresh_access_token(self, access_token)`: makes a call to an arbitrary GET endpoint (right now`/users/houses/mine`) and returns the access token from the response.
* `Authenticator.refresh_access_token(self, force=False)`: checks whether the token will expire within 7 days (threshold is configurable in the constructor).  If not, returns the current `Authentication` object.  If so, it refreshes the token by:
  * Calling `refresh_access_token` on the `Api` object.
  * Extracting the expiration time from the JWT claims
  * Constructing and returning a new `Authentication` object

## Followups

In order for this to have any affect on HomeAssistant, we'd have to update it to make use of the new methods.

I'm not familiar enough with HomeAssistant's internals to know if this is a bad idea, but it seems like a simple change would be to change this:

```python
hass.data[DATA_AUGUST] = AugustData(hass, api, authentication.access_token)
```

to this:

```python
hass.data[DATA_AUGUST] = AugustData(hass, api, authentication)
```

and then use the new `authentication.refresh_access_token()` method somewhere.