### PR TITLE
Get time with a timezone.

### DIFF
--- a/august/authenticator.py
+++ b/august/authenticator.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 import dateutil.parser
@@ -73,7 +73,7 @@ class Authentication:
         return dateutil.parser.parse(self.access_token_expires)
 
     def is_expired(self):
-        return self.parsed_expiration_time() < datetime.utcnow()
+        return self.parsed_expiration_time() < datetime.now(timezone.utc)
 
 
 class AuthenticationState(Enum):
@@ -115,7 +115,7 @@ class Authenticator:
                     # If token is not expired but less then 7 days before it
                     # will.
                     elif (self._authentication.parsed_expiration_time()
-                          - datetime.utcnow()) < timedelta(days=7):
+                          - datetime.now(timezone.utc)) < timedelta(days=7):
                         exp_time = self._authentication.access_token_expires
                         _LOGGER.warning("API Token is going to expire at %s "
                                         "hours. Deleting file %s will result "
@@ -186,7 +186,7 @@ class Authenticator:
         return (self._authentication.state ==
                 AuthenticationState.AUTHENTICATED and (
                     (self._authentication.parsed_expiration_time()
-                     - datetime.utcnow())
+                     - datetime.now(timezone.utc))
                     < self._access_token_renewal_threshold))
 
     def refresh_access_token(self, force=False):


### PR DESCRIPTION
Fixes:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/setup.py", line 174, in
_async_setup_component
    component.setup, hass, processed_config  # type: ignore
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57,
in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/august/__init__.py", line 161, in
setup
    access_token_cache_file=hass.config.path(AUGUST_CONFIG_FILE),
  File "/usr/local/lib/python3.7/site-packages/august/authenticator.py",
line 110, in __init__
    if self._authentication.is_expired():
  File "/usr/local/lib/python3.7/site-packages/august/authenticator.py",
line 76, in is_expired
    return self.parsed_expiration_time() < datetime.utcnow()
TypeError: can't compare offset-naive and offset-aware datetimes