### PR TITLE
Make sure the expire time we get back from the

### DIFF
--- a/august/authenticator.py
+++ b/august/authenticator.py
@@ -208,11 +208,15 @@ class Authenticator:
             return self._authentication
 
         new_expiration = datetime.utcfromtimestamp(jwt_claims['exp'])
+        # The august api always returns expiresAt with a timezone
+        # from the get_session api call
+        # It is important we store access_token_expires formatted
+        # with a timezone for comparison
         self._authentication = Authentication(
             self._authentication.state,
             install_id=self._authentication.install_id,
             access_token=refreshed_token,
-            access_token_expires=new_expiration.isoformat())
+            access_token_expires=new_expiration.astimezone().isoformat())
         self._cache_authentication(self._authentication)
 
         _LOGGER.info("Successfully refreshed access token")

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -76,7 +76,7 @@ class TestAuthenticator(unittest.TestCase):
         access_token = authenticator.refresh_access_token(force=False)
 
         self.assertEqual(token, access_token.access_token)
-        self.assertEqual(datetime.utcfromtimestamp(1337),
+        self.assertEqual(datetime.utcfromtimestamp(1337).astimezone(),
                          access_token.parsed_expiration_time())
 
     @patch('august.api.Api')


### PR DESCRIPTION
refresh api has a timezone so we are consistent for other
comparisons