### PR TITLE
Make sure the expire time we get back from the

### DIFF
--- a/august/authenticator.py
+++ b/august/authenticator.py
@@ -208,11 +208,16 @@ class Authenticator:
             return self._authentication
 
         new_expiration = datetime.utcfromtimestamp(jwt_claims['exp'])
+        # The august api always returns expiresAt in the format
+        # '%Y-%m-%dT%H:%M:%S.%fZ'
+        # from the get_session api call
+        # It is important we store access_token_expires formatted
+        # the same way for compatbility
         self._authentication = Authentication(
             self._authentication.state,
             install_id=self._authentication.install_id,
             access_token=refreshed_token,
-            access_token_expires=new_expiration.isoformat())
+            access_token_expires=new_expiration.strftime('%Y-%m-%dT%H:%M:%S.%fZ'))
         self._cache_authentication(self._authentication)
 
         _LOGGER.info("Successfully refreshed access token")

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timezone, timedelta
+from dateutil.tz import tzutc
 from unittest.mock import Mock, patch
 
 from requests import RequestException
@@ -76,7 +77,7 @@ class TestAuthenticator(unittest.TestCase):
         access_token = authenticator.refresh_access_token(force=False)
 
         self.assertEqual(token, access_token.access_token)
-        self.assertEqual(datetime.utcfromtimestamp(1337),
+        self.assertEqual(datetime.fromtimestamp(1337, tz=tzutc()),
                          access_token.parsed_expiration_time())
 
     @patch('august.api.Api')


### PR DESCRIPTION
refresh api has a timezone so we are consistent for other
comparisons. 

When the token was refreshed it was written without the same
format and no timezone which broke other comparisons

Once this is merged, I'll put in a PR to home-assistant to add support
for refreshing the tokens

Preliminary work is here 
https://github.com/bdraco/august/tree/test_pyaug_token_refresh