### PR TITLE
Hide implementation details with exceptions

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ august/authenticator.py
 august/bridge.py
 august/device.py
 august/doorbell.py
+august/exceptions.py
 august/keypad.py
 august/lock.py
 august/pin.py

--- a/august/api.py
+++ b/august/api.py
@@ -1,17 +1,24 @@
+import json
 import logging
 import time
 
 from requests import Session, request
+from requests.exceptions import HTTPError
 
-from august.activity import (ACTIVITY_ACTIONS_DOOR_OPERATION,
-                             ACTIVITY_ACTIONS_DOORBELL_DING,
-                             ACTIVITY_ACTIONS_DOORBELL_MOTION,
-                             ACTIVITY_ACTIONS_DOORBELL_VIEW,
-                             ACTIVITY_ACTIONS_LOCK_OPERATION,
-                             DoorbellDingActivity, DoorbellMotionActivity,
-                             DoorbellViewActivity, DoorOperationActivity,
-                             LockOperationActivity)
+from august.activity import (
+    ACTIVITY_ACTIONS_DOOR_OPERATION,
+    ACTIVITY_ACTIONS_DOORBELL_DING,
+    ACTIVITY_ACTIONS_DOORBELL_MOTION,
+    ACTIVITY_ACTIONS_DOORBELL_VIEW,
+    ACTIVITY_ACTIONS_LOCK_OPERATION,
+    DoorbellDingActivity,
+    DoorbellMotionActivity,
+    DoorbellViewActivity,
+    DoorOperationActivity,
+    LockOperationActivity,
+)
 from august.doorbell import Doorbell, DoorbellDetail
+from august.exceptions import AugustApiHTTPError
 from august.lock import Lock, LockDetail, LockDoorStatus, LockStatus
 from august.pin import Pin
 
@@ -91,8 +98,7 @@ def _determine_lock_door_status(status):
 
 
 class Api:
-    def __init__(self, timeout=10, command_timeout=60,
-                 http_session: Session = None):
+    def __init__(self, timeout=10, command_timeout=60, http_session: Session = None):
         self._timeout = timeout
         self._command_timeout = command_timeout
         self._http_session = http_session
@@ -105,7 +111,8 @@ class Api:
                 "installId": install_id,
                 "identifier": identifier,
                 "password": password,
-            })
+            },
+        )
 
         return response
 
@@ -114,38 +121,36 @@ class Api:
             "post",
             API_SEND_VERIFICATION_CODE_URLS[login_method],
             access_token=access_token,
-            json={
-                "value": username
-            })
+            json={"value": username},
+        )
 
         return response
 
-    def validate_verification_code(self, access_token, login_method, username,
-                                   verification_code):
+    def validate_verification_code(
+        self, access_token, login_method, username, verification_code
+    ):
         response = self._call_api(
             "post",
             API_VALIDATE_VERIFICATION_CODE_URLS[login_method],
             access_token=access_token,
-            json={
-                login_method: username,
-                "code": str(verification_code)
-            })
+            json={login_method: username, "code": str(verification_code)},
+        )
 
         return response
 
     def get_doorbells(self, access_token):
-        json = self._call_api(
-            "get",
-            API_GET_DOORBELLS_URL,
-            access_token=access_token).json()
+        json_dict = self._call_api(
+            "get", API_GET_DOORBELLS_URL, access_token=access_token
+        ).json()
 
-        return [Doorbell(device_id, data) for device_id, data in json.items()]
+        return [Doorbell(device_id, data) for device_id, data in json_dict.items()]
 
     def get_doorbell_detail(self, access_token, doorbell_id):
         response = self._call_api(
             "get",
             API_GET_DOORBELL_URL.format(doorbell_id=doorbell_id),
-            access_token=access_token)
+            access_token=access_token,
+        )
 
         return DoorbellDetail(response.json())
 
@@ -153,15 +158,13 @@ class Api:
         self._call_api(
             "put",
             API_WAKEUP_DOORBELL_URL.format(doorbell_id=doorbell_id),
-            access_token=access_token)
+            access_token=access_token,
+        )
 
         return True
 
     def get_houses(self, access_token):
-        response = self._call_api(
-            "get",
-            API_GET_HOUSES_URL,
-            access_token=access_token)
+        response = self._call_api("get", API_GET_HOUSES_URL, access_token=access_token)
 
         return response.json()
 
@@ -169,7 +172,8 @@ class Api:
         response = self._call_api(
             "get",
             API_GET_HOUSE_URL.format(house_id=house_id),
-            access_token=access_token)
+            access_token=access_token,
+        )
 
         return response.json()
 
@@ -178,9 +182,8 @@ class Api:
             "get",
             API_GET_HOUSE_ACTIVITIES_URL.format(house_id=house_id),
             access_token=access_token,
-            params={
-                "limit": limit,
-            })
+            params={"limit": limit},
+        )
 
         activities = []
         for activity_json in response.json():
@@ -200,12 +203,11 @@ class Api:
         return activities
 
     def get_locks(self, access_token):
-        json = self._call_api(
-            "get",
-            API_GET_LOCKS_URL,
-            access_token=access_token).json()
+        json_dict = self._call_api(
+            "get", API_GET_LOCKS_URL, access_token=access_token
+        ).json()
 
-        return [Lock(device_id, data) for device_id, data in json.items()]
+        return [Lock(device_id, data) for device_id, data in json_dict.items()]
 
     def get_operable_locks(self, access_token):
         locks = self.get_locks(access_token)
@@ -214,68 +216,70 @@ class Api:
 
     def get_lock_detail(self, access_token, lock_id):
         response = self._call_api(
-            "get",
-            API_GET_LOCK_URL.format(lock_id=lock_id),
-            access_token=access_token)
+            "get", API_GET_LOCK_URL.format(lock_id=lock_id), access_token=access_token
+        )
 
         return LockDetail(response.json())
 
     def get_lock_status(self, access_token, lock_id, door_status=False):
-        json = self._call_api(
+        json_dict = self._call_api(
             "get",
             API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
-            access_token=access_token).json()
-
-        if door_status:
-            return (_determine_lock_status(json.get("status")),
-                    _determine_lock_door_status(json.get("doorState")))
-
-        return _determine_lock_status(json.get("status"))
-
-    def get_lock_door_status(self, access_token, lock_id, lock_status=False):
-        json = self._call_api(
-            "get",
-            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
-            access_token=access_token).json()
-
-        if lock_status:
-            return (_determine_lock_door_status(json.get("doorState")),
-                    _determine_lock_status(json.get("status")))
-
-        return _determine_lock_door_status(json.get("doorState"))
-
-    def get_pins(self, access_token, lock_id):
-        json = self._call_api(
-            "get",
-            API_GET_PINS_URL.format(lock_id=lock_id),
-            access_token=access_token
+            access_token=access_token,
         ).json()
 
-        return [Pin(pin_json) for pin_json in json.get('loaded', [])]
+        if door_status:
+            return (
+                _determine_lock_status(json_dict.get("status")),
+                _determine_lock_door_status(json_dict.get("doorState")),
+            )
+
+        return _determine_lock_status(json_dict.get("status"))
+
+    def get_lock_door_status(self, access_token, lock_id, lock_status=False):
+        json_dict = self._call_api(
+            "get",
+            API_GET_LOCK_STATUS_URL.format(lock_id=lock_id),
+            access_token=access_token,
+        ).json()
+
+        if lock_status:
+            return (
+                _determine_lock_door_status(json_dict.get("doorState")),
+                _determine_lock_status(json_dict.get("status")),
+            )
+
+        return _determine_lock_door_status(json_dict.get("doorState"))
+
+    def get_pins(self, access_token, lock_id):
+        json_dict = self._call_api(
+            "get", API_GET_PINS_URL.format(lock_id=lock_id), access_token=access_token
+        ).json()
+
+        return [Pin(pin_json) for pin_json in json_dict.get("loaded", [])]
 
     def lock(self, access_token, lock_id):
-        json = self._call_api(
+        json_dict = self._call_api(
             "put",
             API_LOCK_URL.format(lock_id=lock_id),
             access_token=access_token,
-            timeout=self._command_timeout).json()
+            timeout=self._command_timeout,
+        ).json()
 
-        return _determine_lock_status(json.get("status"))
+        return _determine_lock_status(json_dict.get("status"))
 
     def unlock(self, access_token, lock_id):
-        json = self._call_api(
+        json_dict = self._call_api(
             "put",
             API_UNLOCK_URL.format(lock_id=lock_id),
             access_token=access_token,
-            timeout=self._command_timeout).json()
+            timeout=self._command_timeout,
+        ).json()
 
-        return _determine_lock_status(json.get("status"))
+        return _determine_lock_status(json_dict.get("status"))
 
     def refresh_access_token(self, access_token):
-        response = self._call_api(
-            "get",
-            API_GET_HOUSES_URL,
-            access_token=access_token)
+        response = self._call_api("get", API_GET_HOUSES_URL, access_token=access_token)
 
         return response.headers[HEADER_AUGUST_ACCESS_TOKEN]
 
@@ -288,25 +292,65 @@ class Api:
         if "timeout" not in kwargs:
             kwargs["timeout"] = self._timeout
 
-        _LOGGER.debug("About to call %s with header=%s and payload=%s", url,
-                      kwargs["headers"], payload)
+        _LOGGER.debug(
+            "About to call %s with header=%s and payload=%s",
+            url,
+            kwargs["headers"],
+            payload,
+        )
 
         attempts = 0
         while attempts < 10:
             attempts += 1
-            response = self._http_session.request(method, url, **kwargs) if \
-                self._http_session is not None else \
-                request(method, url, **kwargs)
-            _LOGGER.debug("Received API response: %s, %s",
-                          response.status_code,
-                          response.content)
+            response = (
+                self._http_session.request(method, url, **kwargs)
+                if self._http_session is not None
+                else request(method, url, **kwargs)
+            )
+            _LOGGER.debug(
+                "Received API response: %s, %s", response.status_code, response.content
+            )
             if response.status_code == 429:
                 _LOGGER.debug(
                     "August sent a 429 (attempt: %d), sleeping and trying again",
-                    attempts)
+                    attempts,
+                )
                 time.sleep(2.5)
                 continue
             break
 
-        response.raise_for_status()
+        _raise_response_exceptions(response)
+
         return response
+
+
+def _raise_response_exceptions(response):
+    try:
+        response.raise_for_status()
+    except HTTPError as err:
+        if err.response.status_code == 422:
+            raise AugustApiHTTPError(
+                "The operation failed because the bridge (connect) is offline.",
+                response=err.response,
+            ) from err
+        if err.response.status_code == 423:
+            raise AugustApiHTTPError(
+                "The operation failed because the bridge (connect) is in use.",
+                response=err.response,
+            ) from err
+        if err.response.status_code == 408:
+            raise AugustApiHTTPError(
+                "The operation timed out because the bridge (connect) failed to respond.",
+                response=err.response,
+            ) from err
+        if err.response.headers.get("content-type") == "application/json":
+            # 4XX and 5XX errors return a json error
+            # like b'{"code":97,"message":"Bridge in use"}'
+            # that is user consumable
+            json_dict = json.loads(err.response.content)
+            failure_message = json_dict.get("message")
+            raise AugustApiHTTPError(
+                "The operation failed because: " + failure_message,
+                response=err.response,
+            ) from err
+        raise err

--- a/august/exceptions.py
+++ b/august/exceptions.py
@@ -1,0 +1,5 @@
+from requests.exceptions import HTTPError
+
+
+class AugustApiHTTPError(HTTPError):
+    """An august api error with a friendly user consumable string."""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-august',
-    version='0.13.0',
+    version='0.14.0',
     packages=['august'],
     url='https://github.com/snjoetw/py-august',
     license='MIT',


### PR DESCRIPTION
The exceptions returned from the api requests should
be more helpful to users so they can figure out how
to resolve them.  Home assistant has issues opened
when a bridge if offline or unavailable because users
do not understand the exception being provided.