### PR TITLE
Add door status to lock detail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-august',
-    version='0.14.0',
+    version='0.15.0',
     packages=['august'],
     url='https://github.com/snjoetw/py-august',
     license='MIT',

--- a/tests/fixtures/get_lock.online_with_doorsense.json
+++ b/tests/fixtures/get_lock.online_with_doorsense.json
@@ -20,7 +20,7 @@
    "LockID" : "ABC",
    "LockName" : "Online door with doorsense",
    "LockStatus" : {
-      "dateTime" : "2000-00-00T00:00:00.447Z",
+      "dateTime" : "2017-12-10T04:48:30.272Z",
       "doorState" : "open",
       "isLockStatusChanged" : false,
       "status" : "locked",


### PR DESCRIPTION
In order to reduce the number of api calls we can
now get the door status from the single lock detail
endpoint since it is contained inside the detail api.

Provide sets for the lock status and door state in
the LockDetail so they can be updated with data
from the activity api