### PR TITLE
Add lock_return_activity and unlock_return_activity apis (additional reduction in august api calls)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -11,3 +11,4 @@ august/exceptions.py
 august/keypad.py
 august/lock.py
 august/pin.py
+august/util.py

--- a/august/lock.py
+++ b/august/lock.py
@@ -9,8 +9,8 @@ from august.keypad import KeypadDetail
 
 LOCKED_STATUS = ("locked", "kAugLockState_Locked")
 UNLOCKED_STATUS = ("unlocked", "kAugLockState_Unlocked")
-CLOSED_STATUS = ("closed", "kAugLockDoorState_Closed")
-OPEN_STATUS = ("open", "kAugLockDoorState_Open")
+CLOSED_STATUS = ("closed", "kAugLockDoorState_Closed", "kAugDoorState_Closed")
+OPEN_STATUS = ("open", "kAugLockDoorState_Open", "kAugDoorState_Open")
 
 
 class Lock(Device):
@@ -160,3 +160,12 @@ def determine_door_state(status):
     if status in OPEN_STATUS:
         return LockDoorStatus.OPEN
     return LockDoorStatus.UNKNOWN
+
+
+def door_state_to_string(door_status):
+    """Returns the normalized value that determine_door_state represents."""
+    if door_status == LockDoorStatus.OPEN:
+        return "dooropen"
+    if door_status == LockDoorStatus.CLOSED:
+        return "doorclosed"
+    raise ValueError

--- a/august/util.py
+++ b/august/util.py
@@ -1,0 +1,35 @@
+import datetime
+
+from august.activity import (
+    ACTIVITY_ACTION_STATES,
+    DoorOperationActivity,
+    LockOperationActivity,
+)
+
+
+def update_lock_detail_from_activity(lock_detail, activity):
+    """Update the LockDetail from an activity."""
+    activity_end_time_utc = as_utc_from_local(activity.activity_end_time)
+    if activity.house_id != lock_detail.house_id:
+        raise ValueError
+    if activity.device_id != lock_detail.device_id:
+        raise ValueError
+    if isinstance(activity, LockOperationActivity):
+        if lock_detail.lock_status_datetime >= activity_end_time_utc:
+            return False
+        lock_detail.lock_status = ACTIVITY_ACTION_STATES[activity.action]
+        lock_detail.lock_status_datetime = activity_end_time_utc
+    elif isinstance(activity, DoorOperationActivity):
+        if lock_detail.door_state_datetime >= activity_end_time_utc:
+            return False
+        lock_detail.door_state = ACTIVITY_ACTION_STATES[activity.action]
+        lock_detail.door_state_datetime = activity_end_time_utc
+    else:
+        raise ValueError
+
+    return True
+
+
+def as_utc_from_local(dtime):
+    """Converts the datetime returned from an activity to UTC."""
+    return dtime.astimezone(tz=datetime.timezone.utc)

--- a/august/util.py
+++ b/august/util.py
@@ -10,8 +10,6 @@ from august.activity import (
 def update_lock_detail_from_activity(lock_detail, activity):
     """Update the LockDetail from an activity."""
     activity_end_time_utc = as_utc_from_local(activity.activity_end_time)
-    if activity.house_id != lock_detail.house_id:
-        raise ValueError
     if activity.device_id != lock_detail.device_id:
         raise ValueError
     if isinstance(activity, LockOperationActivity):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-august',
-    version='0.14.0',
+    version='0.15.0',
     packages=['august'],
     url='https://github.com/snjoetw/py-august',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-august',
-    version='0.16.0',
+    version='0.17.0',
     packages=['august'],
     url='https://github.com/snjoetw/py-august',
     license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='py-august',
-    version='0.15.0',
+    version='0.16.0',
     packages=['august'],
     url='https://github.com/snjoetw/py-august',
     license='MIT',

--- a/tests/fixtures/door_closed_activity.json
+++ b/tests/fixtures/door_closed_activity.json
@@ -1,0 +1,35 @@
+{
+  "action" : "doorclosed",
+  "callingUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  },
+  "dateTime" : 1582007217000,
+  "deviceID" : "ABC",
+  "deviceName" : "MockHouse Tech Room Door",
+  "deviceType" : "lock",
+  "entities" : {
+     "activity" : "activityId",
+     "callingUser" : "deleted",
+     "device" : "ABC",
+     "house" : "123",
+     "otherUser" : "deleted"
+  },
+  "house" : {
+     "houseID" : "123",
+     "houseName" : "MockHouse"
+  },
+  "info" : {
+     "DateLogActionID" : "ABC+Time"
+  },
+  "otherUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  }
+}

--- a/tests/fixtures/door_closed_activity_wrong_deviceid.json
+++ b/tests/fixtures/door_closed_activity_wrong_deviceid.json
@@ -1,0 +1,35 @@
+{
+  "action" : "doorclosed",
+  "callingUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  },
+  "dateTime" : 1582007217000,
+  "deviceID" : "notABC",
+  "deviceName" : "MockHouse Tech Room Door",
+  "deviceType" : "lock",
+  "entities" : {
+     "activity" : "activityId",
+     "callingUser" : "deleted",
+     "device" : "ABC",
+     "house" : "123",
+     "otherUser" : "deleted"
+  },
+  "house" : {
+     "houseID" : "123",
+     "houseName" : "MockHouse"
+  },
+  "info" : {
+     "DateLogActionID" : "ABC+Time"
+  },
+  "otherUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  }
+}

--- a/tests/fixtures/door_closed_activity_wrong_houseid.json
+++ b/tests/fixtures/door_closed_activity_wrong_houseid.json
@@ -1,0 +1,35 @@
+{
+  "action" : "doorclosed",
+  "callingUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  },
+  "dateTime" : 1582007217000,
+  "deviceID" : "ABC",
+  "deviceName" : "MockHouse Tech Room Door",
+  "deviceType" : "lock",
+  "entities" : {
+     "activity" : "activityId",
+     "callingUser" : "deleted",
+     "device" : "ABC",
+     "house" : "not123",
+     "otherUser" : "deleted"
+  },
+  "house" : {
+     "houseID" : "not123",
+     "houseName" : "MockHouse"
+  },
+  "info" : {
+     "DateLogActionID" : "ABC+Time"
+  },
+  "otherUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  }
+}

--- a/tests/fixtures/door_open_activity.json
+++ b/tests/fixtures/door_open_activity.json
@@ -1,0 +1,35 @@
+{
+  "action" : "dooropen",
+  "callingUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  },
+  "dateTime" : 1582007219000,
+  "deviceID" : "ABC",
+  "deviceName" : "MockHouse Tech Room Door",
+  "deviceType" : "lock",
+  "entities" : {
+     "activity" : "ActivityId",
+     "callingUser" : "deleted",
+     "device" : "ABC",
+     "house" : "123",
+     "otherUser" : "deleted"
+  },
+  "house" : {
+     "houseID" : "123",
+     "houseName" : "MockHouse"
+  },
+  "info" : {
+     "DateLogActionID" : "ABC+Time"
+  },
+  "otherUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  }
+}

--- a/tests/fixtures/get_lock.online_with_doorsense.json
+++ b/tests/fixtures/get_lock.online_with_doorsense.json
@@ -20,7 +20,7 @@
    "LockID" : "ABC",
    "LockName" : "Online door with doorsense",
    "LockStatus" : {
-      "dateTime" : "2000-00-00T00:00:00.447Z",
+      "dateTime" : "2017-12-10T04:48:30.272Z",
       "doorState" : "open",
       "isLockStatusChanged" : false,
       "status" : "locked",

--- a/tests/fixtures/lock.json
+++ b/tests/fixtures/lock.json
@@ -1,0 +1,26 @@
+{
+   "resultsFromOperationCache" : false,
+   "retryCount" : 1,
+   "info" : {
+      "lockType" : "lock_version_3",
+      "lockID" : "ABC123",
+      "lockStatusChanged" : true,
+      "rssi" : -87,
+      "wlanRSSI" : -42,
+      "context" : {
+         "startDate" : "2020-02-19T19:44:54.370Z",
+         "transactionID" : "transid",
+         "retryCount" : 1
+      },
+      "serialNumber" : "serial",
+      "action" : "lock",
+      "wlanSNR" : 56,
+      "duration" : 3119,
+      "startTime" : "2020-02-19T19:44:54.371Z",
+      "serial" : "serial",
+      "bridgeID" : "brdigeid"
+   },
+   "doorState" : "kAugDoorState_Closed",
+   "status" : "kAugLockState_Locked",
+   "totalTime" : 3133
+}

--- a/tests/fixtures/lock_activity.json
+++ b/tests/fixtures/lock_activity.json
@@ -1,0 +1,35 @@
+ {
+    "action" : "lock",
+    "callingUser" : {
+       "FirstName" : "MockHouse",
+       "LastName" : "House",
+       "UserID" : "mockUserId2"
+    },
+    "dateTime" : 1582007218000,
+    "deviceID" : "ABC",
+    "deviceName" : "MockHouseTDoor",
+    "deviceType" : "lock",
+    "entities" : {
+       "activity" : "mockActivity2",
+       "callingUser" : "mockUserId2",
+       "device" : "ABC",
+       "house" : "123",
+       "otherUser" : "deleted"
+    },
+    "house" : {
+       "houseID" : "123",
+       "houseName" : "MockHouse"
+    },
+    "info" : {
+       "DateLogActionID" : "ABC+Time",
+       "remote" : true
+    },
+    "otherUser" : {
+       "FirstName" : "Unknown",
+       "LastName" : "User",
+       "PhoneNo" : "deleted",
+       "UserID" : "deleted",
+       "UserName" : "deleteduser"
+    }
+ }
+

--- a/tests/fixtures/lock_without_doorstate.json
+++ b/tests/fixtures/lock_without_doorstate.json
@@ -1,0 +1,25 @@
+{
+   "resultsFromOperationCache" : false,
+   "retryCount" : 1,
+   "info" : {
+      "lockType" : "lock_version_3",
+      "lockID" : "ABC123",
+      "lockStatusChanged" : true,
+      "rssi" : -87,
+      "wlanRSSI" : -42,
+      "context" : {
+         "startDate" : "2020-02-19T19:44:54.370Z",
+         "transactionID" : "transid",
+         "retryCount" : 1
+      },
+      "serialNumber" : "serial",
+      "action" : "lock",
+      "wlanSNR" : 56,
+      "duration" : 3119,
+      "startTime" : "2020-02-19T19:44:54.371Z",
+      "serial" : "serial",
+      "bridgeID" : "brdigeid"
+   },
+   "status" : "kAugLockState_Locked",
+   "totalTime" : 3133
+}

--- a/tests/fixtures/unlock.json
+++ b/tests/fixtures/unlock.json
@@ -1,0 +1,26 @@
+{
+   "resultsFromOperationCache" : false,
+   "info" : {
+      "bridgeID" : "bridgeid",
+      "duration" : 3773,
+      "lockStatusChanged" : true,
+      "serial" : "serial",
+      "startTime" : "2020-02-19T19:44:26.745Z",
+      "lockID" : "ABC",
+      "context" : {
+         "transactionID" : "transid",
+         "retryCount" : 1,
+         "startDate" : "2020-02-19T19:44:26.744Z"
+      },
+      "lockType" : "lock_version_3",
+      "serialNumber" : "serialnum",
+      "wlanRSSI" : -41,
+      "action" : "unlock",
+      "rssi" : -88,
+      "wlanSNR" : 58
+   },
+   "status" : "kAugLockState_Unlocked",
+   "totalTime" : 3784,
+   "retryCount" : 1,
+   "doorState" : "kAugDoorState_Closed"
+}

--- a/tests/fixtures/unlock_activity.json
+++ b/tests/fixtures/unlock_activity.json
@@ -1,0 +1,34 @@
+{
+  "action" : "unlock",
+  "callingUser" : {
+     "FirstName" : "MockHouse",
+     "LastName" : "House",
+     "UserID" : "mockUserId2"
+  },
+  "dateTime" : 1582007217000,
+  "deviceID" : "ABC",
+  "deviceName" : "MockHouseXDoor",
+  "deviceType" : "lock",
+  "entities" : {
+     "activity" : "ActivityId",
+     "callingUser" : "mockUserId2",
+     "device" : "ABC",
+     "house" : "123",
+     "otherUser" : "deleted"
+  },
+  "house" : {
+     "houseID" : "123",
+     "houseName" : "MockHouse"
+  },
+  "info" : {
+     "DateLogActionID" : "ABC+Time",
+     "remote" : true
+  },
+  "otherUser" : {
+     "FirstName" : "Unknown",
+     "LastName" : "User",
+     "PhoneNo" : "deleted",
+     "UserID" : "deleted",
+     "UserName" : "deleteduser"
+  }
+}

--- a/tests/fixtures/unlock_without_doorstate.json
+++ b/tests/fixtures/unlock_without_doorstate.json
@@ -1,0 +1,25 @@
+{
+   "resultsFromOperationCache" : false,
+   "info" : {
+      "bridgeID" : "bridgeid",
+      "duration" : 3773,
+      "lockStatusChanged" : true,
+      "serial" : "serial",
+      "startTime" : "2020-02-19T19:44:26.745Z",
+      "lockID" : "ABC123",
+      "context" : {
+         "transactionID" : "transid",
+         "retryCount" : 1,
+         "startDate" : "2020-02-19T19:44:26.744Z"
+      },
+      "lockType" : "lock_version_3",
+      "serialNumber" : "serialnum",
+      "wlanRSSI" : -41,
+      "action" : "unlock",
+      "rssi" : -88,
+      "wlanSNR" : 58
+   },
+   "status" : "kAugLockState_Unlocked",
+   "totalTime" : 3784,
+   "retryCount" : 1
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -386,6 +386,134 @@ class TestApi(unittest.TestCase):
         self.assertEqual(LockDoorStatus.UNKNOWN, door_status)
 
     @requests_mock.Mocker()
+    def test_lock_from_fixture(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put", API_LOCK_URL.format(lock_id=lock_id), text=load_fixture("lock.json")
+        )
+
+        api = Api()
+        status = api.lock(ACCESS_TOKEN, lock_id)
+
+        self.assertEqual(LockStatus.LOCKED, status)
+
+    @requests_mock.Mocker()
+    def test_unlock_from_fixture(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put",
+            API_UNLOCK_URL.format(lock_id=lock_id),
+            text=load_fixture("unlock.json"),
+        )
+
+        api = Api()
+        status = api.unlock(ACCESS_TOKEN, lock_id)
+
+        self.assertEqual(LockStatus.UNLOCKED, status)
+
+    @requests_mock.Mocker()
+    def test_lock_return_activities_from_fixture(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put", API_LOCK_URL.format(lock_id=lock_id), text=load_fixture("lock.json")
+        )
+
+        api = Api()
+        activities = api.lock_return_activities(ACCESS_TOKEN, lock_id)
+        expected_lock_dt = dateutil.parser.parse("2020-02-19T19:44:54.371Z").replace(
+            tzinfo=None
+        )
+
+        self.assertEqual(len(activities), 2)
+        self.assertIsInstance(activities[0], august.activity.LockOperationActivity)
+        self.assertEqual(activities[0].device_id, "ABC123")
+        self.assertEqual(activities[0].device_type, "lock")
+        self.assertEqual(activities[0].action, "lock")
+        self.assertEqual(activities[0].activity_start_time, expected_lock_dt)
+        self.assertEqual(activities[0].activity_end_time, expected_lock_dt)
+        self.assertIsInstance(activities[1], august.activity.DoorOperationActivity)
+        self.assertEqual(activities[1].device_id, "ABC123")
+        self.assertEqual(activities[1].device_type, "lock")
+        self.assertEqual(activities[1].action, "doorclosed")
+        self.assertEqual(activities[0].activity_start_time, expected_lock_dt)
+        self.assertEqual(activities[0].activity_end_time, expected_lock_dt)
+
+    @requests_mock.Mocker()
+    def test_unlock_return_activities_from_fixture(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put",
+            API_UNLOCK_URL.format(lock_id=lock_id),
+            text=load_fixture("unlock.json"),
+        )
+
+        api = Api()
+        activities = api.unlock_return_activities(ACCESS_TOKEN, lock_id)
+        expected_unlock_dt = dateutil.parser.parse("2020-02-19T19:44:26.745Z").replace(
+            tzinfo=None
+        )
+
+        self.assertEqual(len(activities), 2)
+        self.assertIsInstance(activities[0], august.activity.LockOperationActivity)
+        self.assertEqual(activities[0].device_id, "ABC")
+        self.assertEqual(activities[0].device_type, "lock")
+        self.assertEqual(activities[0].action, "unlock")
+        self.assertEqual(activities[0].activity_start_time, expected_unlock_dt)
+        self.assertEqual(activities[0].activity_end_time, expected_unlock_dt)
+        self.assertIsInstance(activities[1], august.activity.DoorOperationActivity)
+        self.assertEqual(activities[1].device_id, "ABC")
+        self.assertEqual(activities[1].device_type, "lock")
+        self.assertEqual(activities[1].action, "doorclosed")
+        self.assertEqual(activities[1].activity_start_time, expected_unlock_dt)
+        self.assertEqual(activities[1].activity_end_time, expected_unlock_dt)
+
+    @requests_mock.Mocker()
+    def test_lock_return_activities_from_fixture_with_no_doorstate(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put",
+            API_LOCK_URL.format(lock_id=lock_id),
+            text=load_fixture("lock_without_doorstate.json"),
+        )
+
+        api = Api()
+        activities = api.lock_return_activities(ACCESS_TOKEN, lock_id)
+        expected_lock_dt = dateutil.parser.parse("2020-02-19T19:44:54.371Z").replace(
+            tzinfo=None
+        )
+
+        self.assertEqual(len(activities), 1)
+        self.assertIsInstance(activities[0], august.activity.LockOperationActivity)
+        self.assertEqual(activities[0].device_id, "ABC123")
+        self.assertEqual(activities[0].device_type, "lock")
+        self.assertEqual(activities[0].action, "lock")
+        self.assertEqual(activities[0].activity_start_time, expected_lock_dt)
+        self.assertEqual(activities[0].activity_end_time, expected_lock_dt)
+
+    @requests_mock.Mocker()
+    def test_unlock_return_activities_from_fixture_with_no_doorstate(self, mock):
+        lock_id = 1234
+        mock.register_uri(
+            "put",
+            API_UNLOCK_URL.format(lock_id=lock_id),
+            text=load_fixture("unlock_without_doorstate.json"),
+        )
+
+        api = Api()
+        activities = api.unlock_return_activities(ACCESS_TOKEN, lock_id)
+        expected_unlock_dt = dateutil.parser.parse("2020-02-19T19:44:26.745Z").replace(
+            tzinfo=None
+        )
+
+        self.assertEqual(len(activities), 1)
+        self.assertIsInstance(activities[0], august.activity.LockOperationActivity)
+        self.assertEqual(activities[0].device_id, "ABC123")
+        self.assertEqual(activities[0].device_type, "lock")
+        self.assertEqual(activities[0].action, "unlock")
+        self.assertEqual(activities[0].activity_start_time, expected_unlock_dt)
+        self.assertEqual(activities[0].activity_end_time, expected_unlock_dt)
+
+    @requests_mock.Mocker()
     def test_lock(self, mock):
         lock_id = 1234
         mock.register_uri(

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,104 @@
+import json
+import os
+import unittest
+
+import dateutil.parser
+import datetime
+
+from august.activity import DoorOperationActivity, LockOperationActivity
+from august.lock import LockDetail, LockDoorStatus, LockStatus
+from august.util import update_lock_detail_from_activity, as_utc_from_local
+
+
+def load_fixture(filename):
+    """Load a fixture."""
+    path = os.path.join(os.path.dirname(__file__), "fixtures", filename)
+    with open(path) as fptr:
+        return fptr.read()
+
+
+class TestLockDetail(unittest.TestCase):
+    def test_update_lock_with_activity(self):
+        lock = LockDetail(
+            json.loads(load_fixture("get_lock.online_with_doorsense.json"))
+        )
+        self.assertEqual("ABC", lock.device_id)
+        self.assertEqual(LockStatus.LOCKED, lock.lock_status)
+        self.assertEqual(LockDoorStatus.OPEN, lock.door_state)
+        self.assertEqual(
+            dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.lock_status_datetime
+        )
+        self.assertEqual(
+            dateutil.parser.parse("2017-12-10T04:48:30.272Z"), lock.door_state_datetime
+        )
+
+        lock_operation_activity = LockOperationActivity(
+            json.loads(load_fixture("lock_activity.json"))
+        )
+        unlock_operation_activity = LockOperationActivity(
+            json.loads(load_fixture("unlock_activity.json"))
+        )
+        open_operation_activity = DoorOperationActivity(
+            json.loads(load_fixture("door_open_activity.json"))
+        )
+        closed_operation_activity = DoorOperationActivity(
+            json.loads(load_fixture("door_closed_activity.json"))
+        )
+        closed_operation_wrong_deviceid_activity = DoorOperationActivity(
+            json.loads(load_fixture("door_closed_activity_wrong_deviceid.json"))
+        )
+        closed_operation_wrong_houseid_activity = DoorOperationActivity(
+            json.loads(load_fixture("door_closed_activity_wrong_houseid.json"))
+        )
+
+        self.assertTrue(
+            update_lock_detail_from_activity(lock, unlock_operation_activity)
+        )
+        self.assertEqual(LockStatus.UNLOCKED, lock.lock_status)
+        self.assertEqual(
+            as_utc_from_local(datetime.datetime.fromtimestamp(1582007217000 / 1000)),
+            lock.lock_status_datetime,
+        )
+
+        self.assertTrue(update_lock_detail_from_activity(lock, lock_operation_activity))
+        self.assertEqual(LockStatus.LOCKED, lock.lock_status)
+        self.assertEqual(
+            as_utc_from_local(datetime.datetime.fromtimestamp(1582007218000 / 1000)),
+            lock.lock_status_datetime,
+        )
+
+        # returns false we send an older activity
+        self.assertFalse(
+            update_lock_detail_from_activity(lock, unlock_operation_activity)
+        )
+
+        self.assertTrue(
+            update_lock_detail_from_activity(lock, closed_operation_activity)
+        )
+        self.assertEqual(LockDoorStatus.CLOSED, lock.door_state)
+        self.assertEqual(
+            as_utc_from_local(datetime.datetime.fromtimestamp(1582007217000 / 1000)),
+            lock.door_state_datetime,
+        )
+
+        self.assertTrue(update_lock_detail_from_activity(lock, open_operation_activity))
+        self.assertEqual(LockDoorStatus.OPEN, lock.door_state)
+        self.assertEqual(
+            as_utc_from_local(datetime.datetime.fromtimestamp(1582007219000 / 1000)),
+            lock.door_state_datetime,
+        )
+
+        # returns false we send an older activity
+        self.assertFalse(
+            update_lock_detail_from_activity(lock, closed_operation_activity)
+        )
+
+        with self.assertRaises(ValueError):
+            update_lock_detail_from_activity(
+                lock, closed_operation_wrong_deviceid_activity
+            )
+
+        with self.assertRaises(ValueError):
+            update_lock_detail_from_activity(
+                lock, closed_operation_wrong_houseid_activity
+            )


### PR DESCRIPTION
    It is now possible to call the lock and unlock remote operation
    and get back a LockOperationActivity that can be consumed by
    update_lock_detail_from_activity.  If the lock supports doorsense,
    a DoorOperationActivity is also returned since the underlying
    August API returns this.
    
    Lock operations now avoid the need to fetch lock details afterward
    which further reduces the number of API calls we make to the
    August API