### PR TITLE
Fix validation code verification passing login_method as a string instead of var

### DIFF
--- a/august/api_common.py
+++ b/august/api_common.py
@@ -171,7 +171,7 @@ class ApiCommon:
             "method": "post",
             "url": API_VALIDATE_VERIFICATION_CODE_URLS[login_method],
             "access_token": access_token,
-            "json": {"login_method": username, "code": str(verification_code)},
+            "json": {login_method: username, "code": str(verification_code)},
         }
 
     def _build_get_doorbells_request(self, access_token):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="py-august",
-    version="0.24.0",
+    version="0.25.0",
     packages=["august"],
     url="https://github.com/snjoetw/py-august",
     license="MIT",


### PR DESCRIPTION
@snjoetw I noticed a refactoring error which broke code verification in the async conversion when I was adding tests to home assistant.

