### PR TITLE
Add dateutil

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,6 @@
 asynctest
 coveralls
+dateutil
 flake8
 mock
 pylint


### PR DESCRIPTION
`dateutil` is a requirement for running the tests.

```bash
+ /usr/bin/pytest -v tests
============================= test session starts ==============================
platform linux -- Python 3.9.0rc1, pytest-6.0.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /builddir/build/BUILD/py-august-0.25.0, configfile: setup.cfg, testpaths: tests
plugins: cov-2.10.1
collecting ... collected 0 items / 6 errors
==================================== ERRORS ====================================
___________________ ERROR collecting tests/test_activity.py ____________________
ImportError while importing test module '/builddir/build/BUILD/py-august-0.25.0/tests/test_activity.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_activity.py:5: in <module>
    from august.activity import (
../../BUILDROOT/python-august-0.25.0-1.fc34.noarch/usr/lib/python3.9/site-packages/august/activity.py:3: in <module>
    import dateutil.parser
E   ModuleNotFoundError: No module named 'dateutil'
```